### PR TITLE
feat(alpha): :sparkles: bootstrap `Accordion` and `AccordionItem` components

### DIFF
--- a/src/lib/components/accordion/Accordion.svelte
+++ b/src/lib/components/accordion/Accordion.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+	import { accordionWrapperInit } from './functions';
+	const testID =
+		process.env.NODE_ENV === 'test' ? 'Accordion' : /* istanbul ignore next */ undefined;
+
+	export let multiSelectable = false;
+	accordionWrapperInit(multiSelectable);
+</script>
+
+<div class="accordion" data-accordion data-testid={testID} {...$$restProps}>
+	<slot />
+</div>
+
+<style lang="scss">
+	.accordion {
+		@import 'components/accordion';
+	}
+</style>

--- a/src/lib/components/accordion/AccordionItem.svelte
+++ b/src/lib/components/accordion/AccordionItem.svelte
@@ -1,0 +1,83 @@
+<script lang="ts">
+	import type { ColorProp, VariantProp } from '../../types/components';
+	import clsx from 'clsx';
+	import { nanoid } from 'nanoid';
+	import { slide } from 'svelte/transition';
+	import { accordionContextInit, accordionItemLifeCycle, scrollIntoView } from './functions';
+	const testID =
+		process.env.NODE_ENV === 'test' ? 'AccordionItem' : /* istanbul ignore next */ undefined;
+
+	export let id = `a-${nanoid(5)}`;
+	export let title = 'Title';
+	export let expanded = false;
+	export let disabled = false;
+	export let color: ColorProp = 'default';
+	export let variant: VariantProp = 'outline';
+	const accordionContext = accordionContextInit();
+	const accordionItemAction = accordionItemLifeCycle(id, expanded, (value) => {
+		expanded = value[id];
+	});
+
+	$: button_id = `ab-${id}`;
+</script>
+
+<div
+	class={clsx(color, variant, 'accordionItem')}
+	class:expanded
+	use:accordionItemAction={accordionContext}
+	data-accordion-item
+	data-testid={testID}
+	{...$$restProps}
+>
+	<button
+		type="button"
+		class="toggler"
+		aria-expanded={expanded}
+		aria-controls={id}
+		aria-disabled={disabled}
+		{disabled}
+		id={button_id}
+		on:click
+		use:scrollIntoView={expanded}
+		on:click={() => accordionContext && accordionContext.toggle({ id, expanded: !expanded })}
+	>
+		<span class="labelContainer">
+			{#if $$slots.icon}
+				<span class="icon">
+					<slot name="icon" />
+				</span>
+			{/if}
+			<span class="label">
+				<span class="title">
+					<slot name="title">{title}</slot>
+				</span>
+				<span class="description">
+					<slot name="description">{title}</slot>
+				</span>
+			</span>
+		</span>
+		<span class="chevron" />
+	</button>
+	{#key expanded}
+		<div
+			class="content"
+			role="region"
+			{id}
+			aria-labelledby={button_id}
+			hidden={!expanded}
+			in:slide={{ duration: 500 }}
+			out:slide|local={{ duration: 500 }}
+		>
+			<slot />
+		</div>
+	{/key}
+</div>
+
+<style lang="scss">
+	.accordionItem {
+		@import 'components/accordionItem';
+		@include accordion-fill;
+		@include accordion-outline;
+		@include accordion-outline-gradient;
+	}
+</style>

--- a/src/lib/components/accordion/functions.ts
+++ b/src/lib/components/accordion/functions.ts
@@ -1,0 +1,76 @@
+import type { useAction } from '$lib/types/global';
+import type { Subscriber, Writable } from 'svelte/store';
+import { getContext, setContext } from 'svelte';
+import { writable } from 'svelte/store';
+
+interface accordionStates {
+	[key: string]: boolean;
+}
+
+export const accordionStates = writable<accordionStates>({});
+export const setupAccordionContext = (multiSelectable: boolean) =>
+	setContext('Accordion', {
+		accordionStates,
+		add: (newItemState: { id: string; expanded?: boolean }) => {
+			accordionStates.update((allItemStates) => ({
+				...allItemStates,
+				[newItemState.id]: newItemState.expanded
+			}));
+		},
+		remove: (newItemState: { id: string; expanded?: boolean }) => {
+			accordionStates.update((allItemStates) => {
+				const allStates = { ...allItemStates };
+				delete allStates[newItemState.id];
+				return allStates;
+			});
+		},
+		toggle: (newItemState: { id: string; expanded?: boolean }) => {
+			accordionStates.update((allItemStates) => {
+				if (!multiSelectable) {
+					Object.keys(allItemStates).forEach((id) => (allItemStates[id] = false));
+				}
+				return { ...allItemStates, [newItemState.id]: newItemState.expanded };
+			});
+		}
+	});
+export const accordionWrapperInit = (multiSelectable: boolean): void => {
+	setupAccordionContext(multiSelectable);
+};
+
+export const scrollIntoView: useAction = (HtmlElement) => {
+	return {
+		update: () => {
+			/* istanbul ignore next */
+			if (HtmlElement.getBoundingClientRect().top < 0) {
+				HtmlElement.scrollIntoView();
+			}
+		}
+	};
+};
+
+export const accordionContextInit = () =>
+	getContext<{
+		accordionStates: Writable<{
+			[key: string]: boolean;
+		}>;
+		add: (newItemState: { id: string; expanded?: boolean }) => void;
+		remove: (newItemState: { id: string; expanded?: boolean }) => void;
+		toggle: (newItemState: { id: string; expanded?: boolean }) => void;
+	}>('Accordion');
+
+export const accordionItemLifeCycle =
+	(
+		id: string,
+		expanded: boolean,
+		storeSubscribe: Subscriber<{ [key: string]: boolean }>
+	): useAction =>
+	(_, accordionContext: ReturnType<typeof accordionContextInit>) => {
+		accordionContext.add({ id, expanded });
+		const unsubscribe = accordionContext.accordionStates.subscribe(storeSubscribe);
+		return {
+			destroy: () => {
+				if (accordionContext) accordionContext.remove({ id });
+				unsubscribe();
+			}
+		};
+	};

--- a/src/lib/components/accordion/index.ts
+++ b/src/lib/components/accordion/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Implementing Accordion component based on https://github.com/metonym/svelte-accessible-accordion
+ *
+ */
+
+import Accordion from './Accordion.svelte';
+import AccordionItem from './AccordionItem.svelte';
+
+export default Accordion;
+export { AccordionItem };

--- a/src/lib/components/card/Card.svelte
+++ b/src/lib/components/card/Card.svelte
@@ -1,20 +1,21 @@
 <script lang="ts">
 	import type { useAction } from '../../types/global';
 	import clsx from 'clsx';
-
 	import type { ColorProp, VariantProp } from '../../types/components/props';
 	import Badge from '../badge';
 	import Title from '../title';
 
+	const testID = process.env.NODE_ENV === 'test' ? 'Card' : /* istanbul ignore next */ undefined;
+
 	export let color: ColorProp = 'primary';
-	export let variant: VariantProp = 'outline';
+	export let variant: VariantProp = 'fill';
 	export let rtl = false;
 	export let useAction: useAction = () => ({});
 	let className: string | undefined = undefined;
 	export { className as class };
 </script>
 
-<div class={clsx('cardContainer', className)} use:useAction>
+<div class={clsx('cardContainer', className)} data-testid={testID} use:useAction>
 	{#if $$slots.title}
 		<div class:rtl class={clsx('cardHeader')}>
 			<Title {color} {variant}><slot name="title" /></Title>

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -9,4 +9,5 @@ export { default as Radio } from './components/radio';
 export { default as Switch } from './components/switch';
 export { default as Input } from './components/input';
 export { default as Modal } from './components/modal';
+export { default as Accordion, AccordionItem } from './components/accordion';
 export { SVGIcon } from './utilities';

--- a/src/lib/scss/components/accordion/_base.scss
+++ b/src/lib/scss/components/accordion/_base.scss
@@ -1,0 +1,13 @@
+@use 'sass:math';
+$base-borderRadius: $borderRadius;
+$base-paddingX: $paddingX * 1.2;
+$base-paddingY: $paddingY * 1.2;
+$base-marginX: $marginX * 2;
+$base-marginY: $marginY;
+& {
+	box-sizing: border-box;
+	position: relative;
+	background-clip: padding-box;
+	border: 0;
+	pointer-events: auto;
+}

--- a/src/lib/scss/components/accordion/index.scss
+++ b/src/lib/scss/components/accordion/index.scss
@@ -1,0 +1,1 @@
+@import './base';

--- a/src/lib/scss/components/accordionItem/_base.scss
+++ b/src/lib/scss/components/accordionItem/_base.scss
@@ -1,0 +1,91 @@
+@use 'sass:math';
+$base-borderRadius: $borderRadius * 0.7;
+$base-paddingX: $paddingX;
+$base-paddingY: $paddingY;
+$base-marginX: $marginX * 2;
+$base-marginY: $marginY * 0.5;
+$base-borderWidth: $borderWidth * 1.5;
+$content-borderWidth: $borderWidth * 2;
+$base-fontSize: 1rem;
+$description-fontSize: 0.8rem;
+
+& {
+	overflow: hidden;
+	will-change: height;
+	transition: color 0.3s, background-color 0.3s, border-radius 0.3s, border 0.3s;
+	border-radius: $base-borderRadius;
+	border-width: $base-borderWidth;
+	border-style: solid;
+	border-color: transparent;
+	&:not(:last-of-type) {
+		margin-bottom: $base-marginY;
+	}
+	&.expanded {
+		> .toggler {
+			> .chevron {
+				transform: rotate(180deg);
+			}
+		}
+	}
+	> .toggler {
+		border-radius: $base-borderRadius;
+		padding: $base-paddingY $base-paddingX;
+		border: none;
+		display: flex;
+		width: 100%;
+		background-color: transparent;
+		font-size: 1rem;
+		justify-content: space-between;
+		align-items: center;
+		background: transparent;
+		outline: none;
+		cursor: pointer;
+		.labelContainer {
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			padding: 0 $base-paddingX;
+			.icon {
+				margin: $base-marginY $base-marginX * 2;
+				transition: color 0.3s;
+			}
+			.label {
+				display: flex;
+				flex-direction: column;
+				text-align: start;
+				.title {
+					font-size: $base-fontSize;
+					transition: color 0.3s;
+					// font-weight: 600;
+				}
+				.description {
+					font-size: $description-fontSize;
+					transition: color 0.3s;
+					// font-weight: 500;
+				}
+			}
+		}
+		> .chevron {
+			margin: $base-marginY $base-marginX * 2;
+			// padding: $base-paddingY $base-paddingX;
+			display: inline-block;
+			width: 1rem;
+			height: 1rem;
+			position: relative;
+			transition: transform 0.3s, background-color 0.3s;
+			-webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="32" height="32" preserveAspectRatio="xMidYMid meet" viewBox="0 0 512 512"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="48" d="M112 184l144 144l144-144"></path></svg>');
+			mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="32" height="32" preserveAspectRatio="xMidYMid meet" viewBox="0 0 512 512"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="48" d="M112 184l144 144l144-144"></path></svg>');
+			-webkit-mask-position: center;
+			mask-position: center;
+			-webkit-mask-size: contain;
+			mask-size: contain;
+		}
+	}
+	> .content {
+		box-sizing: border-box;
+		padding: $base-paddingY $base-paddingX;
+		position: relative;
+		margin: $base-marginY $base-marginX;
+		transition: color 0.3s;
+	}
+}

--- a/src/lib/scss/components/accordionItem/_fill.scss
+++ b/src/lib/scss/components/accordionItem/_fill.scss
@@ -1,0 +1,74 @@
+@use 'sass:math';
+$base-borderRadius: $borderRadius * 0.7;
+$base-paddingX: $paddingX;
+$base-paddingY: $paddingY;
+$base-marginX: $marginX * 2;
+$base-marginY: $marginY * 0.5;
+$base-borderWidth: $borderWidth * 1.5;
+$content-borderWidth: $borderWidth * 2;
+$base-fontSize: 1rem;
+$description-fontSize: 0.8rem;
+
+@mixin accordion-fill {
+	&.fill {
+		border-color: transparent;
+		// background-color: hsl(var(--natural) / 20%);
+		@include action-hover {
+			background-color: hsl(var(--natural) / 40%);
+		}
+		&:focus-within {
+			background-color: hsl(var(--natural) / 60%);
+			// border-color: hsl(var(--base) / 10%);
+		}
+		> .toggler {
+			border: none;
+			background-color: transparent;
+			background: transparent;
+			.labelContainer {
+				.icon {
+					color: hsl(var(--dark) / 100%);
+				}
+				.label {
+					.description {
+						color: hsl(var(--dark) / 100%);
+					}
+				}
+			}
+			.chevron {
+				background-color: hsl(var(--base) / 100%);
+			}
+		}
+
+		&.expanded {
+			background-color: hsl(var(--base) / 100%);
+			@include action-hover {
+				background-color: hsl(var(--base) / 80%);
+			}
+			> .toggler {
+				border: none;
+				background-color: transparent;
+				background: transparent;
+				.labelContainer {
+					.icon {
+						color: hsl(var(--base-font) / 100%);
+					}
+					.label {
+						.title {
+							color: hsl(var(--base-font) / 100%);
+						}
+						.description {
+							color: hsl(var(--base-font) / 100%);
+						}
+					}
+				}
+				.chevron {
+					background-color: hsl(var(--base-font) / 100%);
+				}
+			}
+
+			> .content {
+				color: hsl(var(--base-font) / 100%);
+			}
+		}
+	}
+}

--- a/src/lib/scss/components/accordionItem/_gradient.scss
+++ b/src/lib/scss/components/accordionItem/_gradient.scss
@@ -1,0 +1,111 @@
+@use 'sass:math';
+$base-borderRadius: $borderRadius * 0.7;
+$base-paddingX: $paddingX;
+$base-paddingY: $paddingY;
+$base-marginX: $marginX * 2;
+$base-marginY: $marginY * 0.5;
+$base-borderWidth: $borderWidth * 1.5;
+$content-borderWidth: $borderWidth * 2;
+$base-fontSize: 1rem;
+$description-fontSize: 0.8rem;
+
+@mixin accordion-outline-gradient {
+	&.outline-gradient {
+		border-color: transparent;
+		background-color: transparent;
+		// background-image: linear-gradient(-30deg, hsl(var(--base) / 5%) 33%, hsl(var(--darker) / 15%));
+		border-width: 0;
+		@include action-hover {
+			background-color: hsl(var(--natural) / 40%);
+		}
+		> .toggler {
+			border: none;
+			background-color: transparent;
+			background: transparent;
+			.labelContainer {
+				.icon {
+					color: hsl(var(--dark) / 100%);
+				}
+				.label {
+					.description {
+						color: hsl(var(--dark) / 100%);
+					}
+				}
+			}
+			.chevron {
+				background-color: hsl(var(--base) / 100%);
+			}
+		}
+		&:focus-within {
+			background-color: hsl(var(--natural) / 60%);
+			> .toggler {
+				.labelContainer {
+					.icon {
+						color: hsl(var(--natural-font) / 100%);
+					}
+					.label {
+						.title {
+							color: hsl(var(--natural-font) / 100%);
+						}
+						.description {
+							color: hsl(var(--natural-font) / 100%);
+						}
+					}
+				}
+				.chevron {
+					background-color: hsl(var(--base) / 100%);
+				}
+			}
+		}
+		&.expanded {
+			background-color: hsl(var(--base) / 100%);
+			background-image: linear-gradient(
+				-30deg,
+				hsl(var(--base) / 100%) 33%,
+				hsl(var(--darker) / 100%)
+			);
+			@include action-hover {
+				background-image: linear-gradient(
+					-30deg,
+					hsl(var(--base) / 80%) 33%,
+					hsl(var(--darker) / 80%)
+				);
+				background-color: hsl(var(--base) / 80%);
+			}
+			> .toggler {
+				border: none;
+				background-color: transparent;
+				background: transparent;
+				.labelContainer {
+					.icon {
+						color: hsl(var(--dark-font) / 100%);
+					}
+					.label {
+						.title {
+							color: hsl(var(--dark-font) / 100%);
+						}
+						.description {
+							color: hsl(var(--dark-font) / 100%);
+						}
+					}
+				}
+				.chevron {
+					background-color: hsl(var(--dark-font) / 100%);
+				}
+			}
+
+			> .content {
+				color: hsl(var(--dark-font) / 100%);
+			}
+		}
+		&.rtl {
+			&.expanded {
+				background-image: linear-gradient(
+					30deg,
+					hsl(var(--base) / 90%) 33%,
+					hsl(var(--darker) / 90%)
+				);
+			}
+		}
+	}
+}

--- a/src/lib/scss/components/accordionItem/_outline.scss
+++ b/src/lib/scss/components/accordionItem/_outline.scss
@@ -1,0 +1,48 @@
+@use 'sass:math';
+$base-borderRadius: $borderRadius * 0.7;
+$base-paddingX: $paddingX;
+$base-paddingY: $paddingY;
+$base-marginX: $marginX * 2;
+$base-marginY: $marginY * 0.5;
+$base-borderWidth: $borderWidth * 1.5;
+$content-borderWidth: $borderWidth * 2;
+$base-fontSize: 1rem;
+$description-fontSize: 0.8rem;
+
+@mixin accordion-outline {
+	&.outline {
+		border-color: transparent;
+		@include action-hover {
+			// background-color: hsl(var(--white) / 60%);
+			border-color: hsl(var(--base) / 10%);
+		}
+		&:focus-within {
+			border-color: hsl(var(--base) / 25%);
+		}
+		&.expanded {
+			border-color: hsl(var(--base) / 40%);
+			@include action-hover {
+				// background-color: hsl(var(--white) / 60%);
+				border-color: hsl(var(--base) / 60%);
+			}
+		}
+		> .toggler {
+			border: none;
+			background-color: transparent;
+			background: transparent;
+			.labelContainer {
+				.icon {
+					color: hsl(var(--base) / 100%);
+				}
+				.label {
+					.description {
+						color: hsl(var(--base) / 100%);
+					}
+				}
+			}
+			.chevron {
+				background-color: hsl(var(--base) / 100%);
+			}
+		}
+	}
+}

--- a/src/lib/scss/components/accordionItem/index.scss
+++ b/src/lib/scss/components/accordionItem/index.scss
@@ -1,0 +1,4 @@
+@import './base';
+@import './fill';
+@import './outline';
+@import './gradient';

--- a/src/routes/accordion.svelte
+++ b/src/routes/accordion.svelte
@@ -1,0 +1,164 @@
+<script lang="ts">
+	import { Accordion, AccordionItem, SVGIcon } from '$lib';
+	import Card from '$lib/components/card/Card.svelte';
+	import more from '$lib/svg/icons/more';
+</script>
+
+<Card>
+	<Accordion>
+		<AccordionItem color="default" title="Default">
+			<svelte:fragment slot="icon">
+				<SVGIcon data={more} />
+			</svelte:fragment>
+			Content default
+		</AccordionItem>
+		<AccordionItem variant="outline" color="primary" title="Primary">
+			<svelte:fragment slot="icon">
+				<SVGIcon data={more} />
+			</svelte:fragment>
+
+			<Accordion multiSelectable>
+				<AccordionItem variant="fill" color="danger" title="Danger">
+					<svelte:fragment slot="icon">
+						<SVGIcon data={more} />
+					</svelte:fragment>
+					Content danger
+				</AccordionItem>
+				<AccordionItem variant="fill" color="success" title="Success">
+					<svelte:fragment slot="icon">
+						<SVGIcon data={more} />
+					</svelte:fragment>
+					Content success
+					<Accordion multiSelectable>
+						<AccordionItem variant="fill" color="danger" title="Danger">
+							<svelte:fragment slot="icon">
+								<SVGIcon data={more} />
+							</svelte:fragment>
+							Content danger
+						</AccordionItem>
+						<AccordionItem variant="fill" color="success" title="Success">
+							<svelte:fragment slot="icon">
+								<SVGIcon data={more} />
+							</svelte:fragment>
+							Content success
+						</AccordionItem>
+					</Accordion>
+				</AccordionItem>
+			</Accordion>
+		</AccordionItem>
+		<AccordionItem color="secondary" title="Secondary">
+			<svelte:fragment slot="icon">
+				<SVGIcon data={more} />
+			</svelte:fragment>
+			Content secondary
+		</AccordionItem>
+		<AccordionItem color="warning" title="Warning">
+			<svelte:fragment slot="icon">
+				<SVGIcon data={more} />
+			</svelte:fragment>
+			Content warning
+		</AccordionItem>
+		<AccordionItem color="danger" title="Danger">
+			<svelte:fragment slot="icon">
+				<SVGIcon data={more} />
+			</svelte:fragment>
+			Content danger
+		</AccordionItem>
+		<AccordionItem color="success" title="Success">
+			<svelte:fragment slot="icon">
+				<SVGIcon data={more} />
+			</svelte:fragment>
+			Content success
+		</AccordionItem>
+		<AccordionItem color="info" title="Info">
+			<svelte:fragment slot="icon">
+				<SVGIcon data={more} />
+			</svelte:fragment>
+			Content info
+		</AccordionItem>
+		<AccordionItem variant="fill" color="default" title="Default">
+			<svelte:fragment slot="icon">
+				<SVGIcon data={more} />
+			</svelte:fragment>
+			Content default
+		</AccordionItem>
+		<AccordionItem variant="fill" color="primary" title="Primary">
+			<svelte:fragment slot="icon">
+				<SVGIcon data={more} />
+			</svelte:fragment>
+			Content primary
+		</AccordionItem>
+		<AccordionItem variant="fill" color="secondary" title="Secondary">
+			<svelte:fragment slot="icon">
+				<SVGIcon data={more} />
+			</svelte:fragment>
+			Content secondary
+		</AccordionItem>
+		<AccordionItem variant="fill" color="warning" title="Warning">
+			<svelte:fragment slot="icon">
+				<SVGIcon data={more} />
+			</svelte:fragment>
+			Content warning
+		</AccordionItem>
+		<AccordionItem variant="fill" color="danger" title="Danger">
+			<svelte:fragment slot="icon">
+				<SVGIcon data={more} />
+			</svelte:fragment>
+			Content danger
+		</AccordionItem>
+		<AccordionItem variant="fill" color="success" title="Success">
+			<svelte:fragment slot="icon">
+				<SVGIcon data={more} />
+			</svelte:fragment>
+			Content success
+		</AccordionItem>
+		<AccordionItem variant="fill" color="info" title="Info">
+			<svelte:fragment slot="icon">
+				<SVGIcon data={more} />
+			</svelte:fragment>
+			Content info
+		</AccordionItem>
+
+		<AccordionItem variant="outline-gradient" color="default" title="Default">
+			<svelte:fragment slot="icon">
+				<SVGIcon data={more} />
+			</svelte:fragment>
+			Content default
+		</AccordionItem>
+
+		<AccordionItem variant="outline-gradient" color="primary" title="Primary">
+			<svelte:fragment slot="icon">
+				<SVGIcon data={more} />
+			</svelte:fragment>
+			Content primary
+		</AccordionItem>
+
+		<AccordionItem variant="outline-gradient" color="secondary" title="Secondary">
+			<svelte:fragment slot="icon">
+				<SVGIcon data={more} />
+			</svelte:fragment>
+			Content secondary
+		</AccordionItem>
+
+		<AccordionItem variant="outline-gradient" color="warning" title="Warning">
+			<svelte:fragment slot="icon">
+				<SVGIcon data={more} />
+			</svelte:fragment>
+			Content warning
+		</AccordionItem>
+
+		<AccordionItem variant="outline-gradient" color="danger" title="Danger">
+			<svelte:fragment slot="icon">
+				<SVGIcon data={more} />
+			</svelte:fragment>
+			Content danger
+		</AccordionItem>
+
+		<AccordionItem variant="outline-gradient" color="success" title="Success">
+			<svelte:fragment slot="icon">
+				<SVGIcon data={more} />
+			</svelte:fragment>
+			Content success
+		</AccordionItem>
+	</Accordion>
+</Card>

--- a/src/stories/components/Accordion.stories.svelte
+++ b/src/stories/components/Accordion.stories.svelte
@@ -1,0 +1,117 @@
+<script>
+	import { Meta, Template, Story } from '@storybook/addon-svelte-csf';
+	import Accordion, { AccordionItem } from '$lib/components/accordion';
+	import { SVGIcon } from '$lib/utilities';
+</script>
+
+<Meta
+	title="Components/Accordion"
+	component={Accordion}
+	argTypes={{
+		slot: {
+			control: 'text',
+			defaultValue:
+				'Lorem ipsum dolor sit amet consectetur adipisicing elit. Unde aliquam, facere non dignissimos dolor eveniet fugiat cumque similique a enim alias laboriosam nulla tenetur voluptates placeat recusandae doloremque, eius ex.'
+		},
+		title: {
+			control: 'text',
+			defaultValue: 'Accordion Title'
+		},
+		SvgIcon: {
+			control: 'text'
+		},
+		color: {
+			control: {
+				type: 'select',
+				options: ['primary', 'secondary', 'warning', 'danger', 'success', 'default', 'info']
+			},
+			defaultValue: 'default'
+		},
+		variant: {
+			control: { type: 'select', options: ['fill', 'outline', 'outline-gradient'] }
+		},
+		multiSelectable: {
+			control: { type: 'boolean' },
+			defaultValue: false
+		}
+	}}
+/>
+
+<Template let:args>
+	<Accordion multiSelectable={args.multiSelectable}>
+		{#if args.SvgIcon}
+			<AccordionItem variant="fill" color="success" title="Success" {...args}>
+				<svelte:fragment slot="icon">
+					<SVGIcon data={args.SvgIcon} />
+				</svelte:fragment>
+				{args.slot}
+			</AccordionItem>
+			<AccordionItem variant="outline" color="success" title="Success" {...args}>
+				<svelte:fragment slot="icon">
+					<SVGIcon data={args.SvgIcon} />
+				</svelte:fragment>
+				{args.slot}
+			</AccordionItem>
+			<AccordionItem variant="outline-gradient" color="success" title="Success" {...args}>
+				<svelte:fragment slot="icon">
+					<SVGIcon data={args.SvgIcon} />
+				</svelte:fragment>
+				{args.slot}
+			</AccordionItem>
+		{:else}
+			<AccordionItem variant="fill" color="success" title="Success" {...args}>
+				{args.slot}
+			</AccordionItem>
+			<AccordionItem variant="outline" color="success" title="Success" {...args}>
+				{args.slot}
+			</AccordionItem>
+			<AccordionItem variant="outline-gradient" color="success" title="Success" {...args}>
+				{args.slot}
+			</AccordionItem>
+		{/if}
+	</Accordion>
+</Template>
+
+<Story
+	name="Default"
+	args={{
+		color: 'default'
+	}}
+/>
+<Story
+	name="Primary"
+	args={{
+		color: 'primary'
+	}}
+/>
+<Story
+	name="Secondary"
+	args={{
+		color: 'secondary'
+	}}
+/>
+
+<Story
+	name="Warning"
+	args={{
+		color: 'warning'
+	}}
+/>
+<Story
+	name="Danger"
+	args={{
+		color: 'danger'
+	}}
+/>
+<Story
+	name="Success"
+	args={{
+		color: 'success'
+	}}
+/>
+<Story
+	name="Info"
+	args={{
+		color: 'info'
+	}}
+/>

--- a/src/tests/components/accordion.spec.jsx
+++ b/src/tests/components/accordion.spec.jsx
@@ -1,0 +1,102 @@
+import Accordion from '../container/accordion.test.svelte';
+import { render, fireEvent } from '@testing-library/svelte';
+import { tick } from 'svelte';
+
+describe('Accordion component test suite', () => {
+	it('it works', async () => {
+		const { getByTestId } = render(Accordion);
+		expect(getByTestId('Accordion')).toBeTruthy();
+	});
+	it('test multi selectable prop', async () => {
+		const { getByTestId, getAllByTestId } = render(Accordion, {
+			props: {
+				multiSelectable: true
+			}
+		});
+		expect(getByTestId('Accordion')).toBeTruthy();
+
+		const firstItem = getAllByTestId('AccordionItem')[0];
+		const secondItem = getAllByTestId('AccordionItem')[1];
+		expect(firstItem).not.toHaveClass('expanded');
+		expect(secondItem).not.toHaveClass('expanded');
+		await fireEvent.click(firstItem.querySelector('.toggler'));
+		await fireEvent.click(secondItem.querySelector('.toggler'));
+		expect(firstItem).toHaveClass('expanded');
+		expect(secondItem).toHaveClass('expanded');
+	});
+	it('test single selectable prop', async () => {
+		const { getByTestId, getAllByTestId } = render(Accordion, {
+			props: {
+				multiSelectable: false
+			}
+		});
+		expect(getByTestId('Accordion')).toBeTruthy();
+
+		const firstItem = getAllByTestId('AccordionItem')[0];
+		const secondItem = getAllByTestId('AccordionItem')[1];
+		expect(firstItem).not.toHaveClass('expanded');
+		expect(secondItem).not.toHaveClass('expanded');
+		await fireEvent.click(firstItem.querySelector('.toggler'));
+		expect(firstItem).toHaveClass('expanded');
+		expect(secondItem).not.toHaveClass('expanded');
+		await fireEvent.click(secondItem.querySelector('.toggler'));
+		expect(firstItem).not.toHaveClass('expanded');
+		expect(secondItem).toHaveClass('expanded');
+	});
+});
+describe('AccordionItem component test suite', () => {
+	it('it works', async () => {
+		const { getAllByTestId } = render(Accordion);
+		expect(getAllByTestId('AccordionItem')).toBeTruthy();
+	});
+	it('test multi selectable prop', async () => {
+		const { getByTestId, getAllByTestId } = render(Accordion, { props: { multiSelectable: true } });
+		expect(getByTestId('Accordion')).toBeTruthy();
+		expect(getAllByTestId('AccordionItem')).toBeTruthy();
+	});
+	it('testing custom classes', async () => {
+		const { getAllByTestId, getByText, container } = render(Accordion, {
+			props: { class: 'testClass23 testing58' }
+		});
+		expect(getAllByTestId('AccordionItem')[0]).toHaveClass('testClass23', 'testing58');
+		expect(getAllByTestId('AccordionItem')[1]).toHaveClass('testClass23', 'testing58');
+	});
+
+	it('testing interactive color prop change', async () => {
+		const { getByTestId, getAllByTestId, component } = render(Accordion);
+		expect(getByTestId('Accordion')).toBeTruthy();
+		expect(getAllByTestId('AccordionItem')[0]).toHaveClass('default');
+		expect(getAllByTestId('AccordionItem')[1]).toHaveClass('default');
+		expect(getAllByTestId('AccordionItem')[0]).not.toHaveClass('primary');
+		expect(getAllByTestId('AccordionItem')[1]).not.toHaveClass('primary');
+		component.$$set({ color: 'primary' });
+		await tick();
+		expect(getAllByTestId('AccordionItem')[0]).not.toHaveClass('default');
+		expect(getAllByTestId('AccordionItem')[1]).not.toHaveClass('default');
+		expect(getAllByTestId('AccordionItem')[0]).toHaveClass('primary');
+		expect(getAllByTestId('AccordionItem')[1]).toHaveClass('primary');
+		component.$$set({ color: 'danger' });
+		await tick();
+		expect(getAllByTestId('AccordionItem')[0]).not.toHaveClass('default');
+		expect(getAllByTestId('AccordionItem')[1]).not.toHaveClass('default');
+		expect(getAllByTestId('AccordionItem')[0]).not.toHaveClass('primary');
+		expect(getAllByTestId('AccordionItem')[1]).not.toHaveClass('primary');
+		expect(getAllByTestId('AccordionItem')[0]).toHaveClass('danger');
+		expect(getAllByTestId('AccordionItem')[1]).toHaveClass('danger');
+	});
+
+	it('testing interactive disabled prop change', async () => {
+		const { getByTestId, getAllByTestId, component } = render(Accordion);
+		expect(getByTestId('Accordion')).toBeTruthy();
+		expect(getAllByTestId('AccordionItem')[0].querySelector('button')).not.toHaveAttribute(
+			'disabled'
+		);
+		expect(getAllByTestId('AccordionItem')[1].querySelector('button')).not.toHaveAttribute(
+			'disabled'
+		);
+		component.$$set({ disabled: true });
+		await tick();
+		expect(getAllByTestId('AccordionItem')[0].querySelector('button')).toHaveAttribute('disabled');
+		expect(getAllByTestId('AccordionItem')[1].querySelector('button')).toHaveAttribute('disabled');
+	});
+});

--- a/src/tests/components/card.spec.jsx
+++ b/src/tests/components/card.spec.jsx
@@ -1,0 +1,77 @@
+import Card from '../../lib/components/card';
+import Button from '../../lib/components/button';
+import { render } from '@testing-library/svelte';
+
+describe('Card component test suite', () => {
+	it('it works', async () => {
+		const component = render(<Card />);
+		expect(() => component.getAllByTestId('Card')).not.toThrow();
+	});
+
+	it('testing default classes', async () => {
+		const { getByTestId } = render(Card);
+		expect(getByTestId('Card')).toHaveClass('cardContainer');
+	});
+	it('testing interactive color prop change', async () => {
+		const { getByTestId, component, container } = render(
+			<Card color="primary">
+				<Fragment slot="title">some title</Fragment>
+				<Fragment slot="notification">All rights reserved</Fragment>
+				<strong>Soren Abedi</strong> requested to follow you
+				<Fragment slot="actions">
+					<Button rtl color="primary">
+						Accept
+					</Button>
+					<Button variant="outline" color="primary">
+						X
+					</Button>
+				</Fragment>
+			</Card>
+		);
+		expect(getByTestId('Card').querySelectorAll('.primary').length).toBe(4);
+		expect(getByTestId('Card').querySelectorAll('.default').length).toBe(0);
+	});
+	it('testing interactive variant prop change', async () => {
+		const { getByTestId, component, container } = render(
+			<Card variant="outline" color="warning">
+				<Fragment slot="title">some title</Fragment>
+				<Fragment slot="notification">All rights reserved</Fragment>
+				<strong>Soren Abedi</strong> requested to follow you
+				<Fragment slot="actions">
+					<Button rtl variant="fill" color="primary">
+						Accept
+					</Button>
+					<Button variant="fill" color="primary">
+						X
+					</Button>
+				</Fragment>
+			</Card>
+		);
+		expect(getByTestId('Badge')).toHaveClass('outline', 'warning');
+	});
+	it('testing interactive rtl prop change', async () => {
+		const { getByTestId, component } = render(
+			<Card rtl>
+				<Fragment slot="title">some title</Fragment>
+			</Card>
+		);
+		expect(getByTestId('Card').querySelector('.cardHeader')).toHaveClass('rtl');
+	});
+
+	it('testing custom classes', async () => {
+		const { getByTestId } = render(Card, { props: { class: 'testClass23 testing58' } });
+		expect(getByTestId('Card')).toHaveClass('cardContainer', 'testClass23', 'testing58');
+	});
+	it('testing interactive title slot change', async () => {
+		const { getByTestId } = render(
+			<Card>
+				<Fragment slot="title">some title</Fragment>
+			</Card>
+		);
+		expect(getByTestId('Card').querySelector('h4')).toHaveTextContent('some title');
+	});
+	it('testing no SVGIcon slot', async () => {
+		const { getByTestId } = render(<Card />);
+		expect(getByTestId('Card').innerHTML.includes('</svg>')).toEqual(false);
+	});
+});

--- a/src/tests/container/accordion.test.svelte
+++ b/src/tests/container/accordion.test.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	import { SVGIcon } from '$lib';
+	import Accordion, { AccordionItem } from '$lib/components/accordion';
+	import more from '$lib/svg/icons/more';
+	export let multiSelectable = false;
+</script>
+
+<Accordion {multiSelectable} {...$$restProps}>
+	<AccordionItem {...$$restProps} title="acc-first">
+		<svelte:fragment slot="icon">
+			<SVGIcon data={more} />
+		</svelte:fragment>
+		Content success
+	</AccordionItem>
+	<AccordionItem {...$$restProps} title="acc-last">
+		<svelte:fragment slot="icon">
+			<SVGIcon data={more} />
+		</svelte:fragment>
+		Content success
+	</AccordionItem>
+</Accordion>


### PR DESCRIPTION
- add multiple variant styles
- add associated `Storybook`
- add associated tests
- add missing `Card` component tests

Fixes #37

Signed-off-by: Soren Abedi <soren.abedi@gmail.com>