### PR TITLE
chore(dev): :children_crossing: expose mouse events from components

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6943,7 +6943,7 @@ packages:
       braces: 3.0.2
       glob-parent: 5.1.2
       is-binary-path: 2.1.0
-      is-glob: 4.0.1
+      is-glob: 4.0.3
       normalize-path: 3.0.0
       readdirp: 3.6.0
     optionalDependencies:
@@ -9746,7 +9746,7 @@ packages:
       }
     engines: { node: '>= 6' }
     dependencies:
-      is-glob: 4.0.1
+      is-glob: 4.0.3
 
   /glob-promise/3.4.0_glob@7.2.0:
     resolution:
@@ -10847,6 +10847,7 @@ packages:
     engines: { node: '>=0.10.0' }
     dependencies:
       is-extglob: 2.1.1
+    dev: true
 
   /is-glob/4.0.3:
     resolution:
@@ -10856,7 +10857,6 @@ packages:
     engines: { node: '>=0.10.0' }
     dependencies:
       is-extglob: 2.1.1
-    dev: true
 
   /is-hexadecimal/1.0.4:
     resolution:

--- a/src/lib/components/accordion/AccordionItem.svelte
+++ b/src/lib/components/accordion/AccordionItem.svelte
@@ -27,6 +27,12 @@
 	use:accordionItemAction={accordionContext}
 	data-accordion-item
 	data-testid={testID}
+	on:click
+	on:dblclick
+	on:mouseenter
+	on:mouseleave
+	on:mouseover
+	on:focus
 	{...$$restProps}
 >
 	<button

--- a/src/lib/components/alert/Alert.svelte
+++ b/src/lib/components/alert/Alert.svelte
@@ -19,6 +19,12 @@
 	class:rtl
 	class:shadow
 	use:useAction
+	on:click
+	on:dblclick
+	on:mouseenter
+	on:mouseleave
+	on:mouseover
+	on:focus
 >
 	{#if $$slots.SvgIcon}
 		<span class="icon">

--- a/src/lib/components/avatar/Avatar.svelte
+++ b/src/lib/components/avatar/Avatar.svelte
@@ -26,6 +26,10 @@
 	on:change
 	on:click
 	on:dblclick
+	on:mouseenter
+	on:mouseleave
+	on:mouseover
+	on:focus
 	use:useAction
 >
 	<div class="avatar">

--- a/src/lib/components/badge/Badge.svelte
+++ b/src/lib/components/badge/Badge.svelte
@@ -12,7 +12,18 @@
 	export { className as class };
 </script>
 
-<span class={clsx(color, variant, className)} class:fullWidth data-testid={testID} use:useAction>
+<span
+	class={clsx(color, variant, className)}
+	class:fullWidth
+	data-testid={testID}
+	use:useAction
+	on:click
+	on:dblclick
+	on:mouseenter
+	on:mouseleave
+	on:mouseover
+	on:focus
+>
 	<slot />
 </span>
 

--- a/src/lib/components/button/Button.svelte
+++ b/src/lib/components/button/Button.svelte
@@ -21,6 +21,10 @@
 	class:circle
 	on:click
 	on:dblclick
+	on:mouseenter
+	on:mouseleave
+	on:mouseover
+	on:focus
 	use:useAction
 	data-testid={testID}
 	{...$$restProps}

--- a/src/lib/components/checkbox/Checkbox.svelte
+++ b/src/lib/components/checkbox/Checkbox.svelte
@@ -23,6 +23,10 @@
 		on:change
 		on:click
 		on:dblclick
+		on:mouseenter
+		on:mouseleave
+		on:mouseover
+		on:focus
 		on:input
 		use:useAction
 		{...$$restProps}

--- a/src/lib/components/input/Input.svelte
+++ b/src/lib/components/input/Input.svelte
@@ -36,6 +36,10 @@
 			on:change
 			on:click
 			on:dblclick
+			on:mouseenter
+			on:mouseleave
+			on:mouseover
+			on:focus
 			on:input
 			use:useAction
 			placeholder=" "

--- a/src/lib/components/radio/Radio.svelte
+++ b/src/lib/components/radio/Radio.svelte
@@ -22,6 +22,10 @@
 		on:change
 		on:click
 		on:dblclick
+		on:mouseenter
+		on:mouseleave
+		on:mouseover
+		on:focus
 		on:input
 		use:useAction
 		{...$$restProps}

--- a/src/lib/components/switch/Switch.svelte
+++ b/src/lib/components/switch/Switch.svelte
@@ -19,6 +19,10 @@
 		on:change
 		on:click
 		on:dblclick
+		on:mouseenter
+		on:mouseleave
+		on:mouseover
+		on:focus
 		on:input
 		use:useAction
 	/>

--- a/src/lib/components/title/Title.svelte
+++ b/src/lib/components/title/Title.svelte
@@ -15,6 +15,12 @@
 	class={clsx(color, variant, 'title', className)}
 	use:useAction
 	data-testid={testID}
+	on:click
+	on:dblclick
+	on:mouseenter
+	on:mouseleave
+	on:mouseover
+	on:focus
 	{...$$restProps}
 >
 	<slot />


### PR DESCRIPTION
- exposing `on:mouseenter`, `on:mouseleave`, `on:mouseover` and `on:focus` events from components
- update `package-lock.yml` file

Signed-off-by: Soren Abedi <soren.abedi@gmail.com>