### PR TITLE
refactor(dev): :recycle: Increase code readablity and fix naming issues

### DIFF
--- a/src/lib/components/input/Input.svelte
+++ b/src/lib/components/input/Input.svelte
@@ -61,7 +61,7 @@
 <style lang="scss">
 	.input {
 		@import 'components/input';
-		@include button-fill;
-		@include button-outline;
+		@include input-fill;
+		@include input-outline;
 	}
 </style>

--- a/src/lib/components/modal/Modal.svelte
+++ b/src/lib/components/modal/Modal.svelte
@@ -33,6 +33,17 @@
 </script>
 
 <slot name="trigger" {open} />
+
+<svelte:head>
+	{#if $isOpen}
+		<style>
+			body {
+				overflow: hidden;
+			}
+		</style>
+	{/if}
+</svelte:head>
+
 {#if $isOpen}
 	<div
 		class={clsx('modal', color, className)}

--- a/src/lib/components/modal/functions.ts
+++ b/src/lib/components/modal/functions.ts
@@ -1,4 +1,4 @@
-import type { useAction } from '$lib/types/global';
+import type { useAction } from '../../types/global';
 
 export const keydown =
 	(close: () => void) =>
@@ -13,14 +13,6 @@ export const modalInit =
 	(modalNodeList: HTMLElement[], close: () => void): useAction =>
 	(node: HTMLElement) => {
 		const returnFn = [];
-		/* istanbul ignore else */
-		if (document.body.style.overflow !== 'hidden') {
-			const original = document.body.style.overflow;
-			document.body.style.overflow = 'hidden';
-			returnFn.push(() => {
-				document.body.style.overflow = original;
-			});
-		}
 		document.body.addEventListener('keydown', keydown(close));
 		modalNodeList.push(node);
 		returnFn.push(() => {

--- a/src/lib/scss/components/backdrop/_base.scss
+++ b/src/lib/scss/components/backdrop/_base.scss
@@ -11,9 +11,11 @@ $icon-size: 0.8rem;
 $icon-marginX: 0.125rem;
 
 & {
-	position: absolute;
+	position: fixed;
 	width: 100%;
 	height: 100%;
+	top: 0;
+	right: 0;
 	background-color: hsl(var(--darker) / 50%);
 	&.overlayBlur {
 		background-color: hsl(var(--dark) / 30%);

--- a/src/lib/scss/components/input/_fill.scss
+++ b/src/lib/scss/components/input/_fill.scss
@@ -1,4 +1,4 @@
-@mixin button-fill {
+@mixin input-fill {
 	&.fill {
 		.inputContainer {
 			label {

--- a/src/lib/scss/components/input/_outline.scss
+++ b/src/lib/scss/components/input/_outline.scss
@@ -1,4 +1,4 @@
-@mixin button-outline {
+@mixin input-outline {
 	&.outline {
 		.inputContainer {
 			label {


### PR DESCRIPTION
- change `Input` component scss variant `@mixin` names
- improve body overflow locking logic in `Modal` component
- change `Backdrop` component position style to `fixed`

Signed-off-by: Soren Abedi <soren.abedi@gmail.com>