### PR TITLE
style: :lipstick: add `inherit` color style to `AccordionItem` component

### DIFF
--- a/src/lib/components/accordionItem/AccordionItem.svelte
+++ b/src/lib/components/accordionItem/AccordionItem.svelte
@@ -8,14 +8,15 @@
 		accordionItemLifeCycle,
 		scrollIntoView
 	} from './internal-functions';
+	import SvgParser from '../../utilities/svgParser';
+	import chevronDown from '../../svg/icons/chevron-down';
 	const testID =
 		process.env.NODE_ENV === 'test' ? 'AccordionItem' : /* istanbul ignore next */ undefined;
 
 	export let id = `a-${nanoid(5)}`;
-	export let title = 'Title';
 	export let expanded = false;
 	export let disabled = false;
-	export let color: ColorProp = 'default';
+	export let color: ColorProp | 'inherit' = 'inherit';
 	export let variant: VariantProp = 'outline';
 	const accordionContext = accordionContextInit();
 	const accordionItemAction = accordionItemLifeCycle(id, expanded, (value) => {
@@ -59,14 +60,16 @@
 			{/if}
 			<span class="label">
 				<span class="title">
-					<slot name="title">{title}</slot>
+					<slot name="title" />
 				</span>
 				<span class="description">
-					<slot name="description">{title}</slot>
+					<slot name="description" />
 				</span>
 			</span>
 		</span>
-		<span class="chevron" />
+		<span class="chevron">
+			<SvgParser data={chevronDown} />
+		</span>
 	</button>
 	{#key expanded}
 		<div

--- a/src/lib/scss/components/accordion/_base.scss
+++ b/src/lib/scss/components/accordion/_base.scss
@@ -12,5 +12,6 @@ $base-marginY: $marginY;
 		background-clip: padding-box;
 		border: 0;
 		pointer-events: auto;
+		width: 100%;
 	}
 }

--- a/src/lib/scss/components/accordionItem/_base.scss
+++ b/src/lib/scss/components/accordionItem/_base.scss
@@ -3,7 +3,7 @@ $base-borderRadius: $borderRadius * 0.7;
 $base-paddingX: $paddingX;
 $base-paddingY: $paddingY;
 $base-marginX: $marginX * 2;
-$base-marginY: $marginY * 0.5;
+$base-marginY: $marginY * 20;
 $base-borderWidth: $borderWidth * 1.5;
 $content-borderWidth: $borderWidth * 2;
 $base-fontSize: 1rem;
@@ -47,6 +47,9 @@ $description-fontSize: 0.8rem;
 				justify-content: center;
 				padding: 0 $base-paddingX;
 				.icon {
+					display: flex;
+					align-items: center;
+					justify-content: center;
 					margin: $base-marginY $base-marginX * 2;
 					transition: color 0.3s;
 				}
@@ -54,6 +57,7 @@ $description-fontSize: 0.8rem;
 					display: flex;
 					flex-direction: column;
 					text-align: start;
+					transition: transform 0.3s;
 					.title {
 						font-size: $base-fontSize;
 						transition: color 0.3s;
@@ -73,13 +77,7 @@ $description-fontSize: 0.8rem;
 				width: 1rem;
 				height: 1rem;
 				position: relative;
-				transition: transform 0.3s, background-color 0.3s;
-				-webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="32" height="32" preserveAspectRatio="xMidYMid meet" viewBox="0 0 512 512"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="48" d="M112 184l144 144l144-144"></path></svg>');
-				mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="32" height="32" preserveAspectRatio="xMidYMid meet" viewBox="0 0 512 512"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="48" d="M112 184l144 144l144-144"></path></svg>');
-				-webkit-mask-position: center;
-				mask-position: center;
-				-webkit-mask-size: contain;
-				mask-size: contain;
+				transition: transform 0.3s, color 0.3s;
 			}
 		}
 		> .content {

--- a/src/lib/scss/components/accordionItem/_fill.scss
+++ b/src/lib/scss/components/accordionItem/_fill.scss
@@ -39,7 +39,7 @@ $description-fontSize: 0.8rem;
 				}
 			}
 			.chevron {
-				background-color: hsl(var(--base) / 100%);
+				color: hsl(var(--base) / 100%);
 			}
 		}
 
@@ -66,7 +66,7 @@ $description-fontSize: 0.8rem;
 					}
 				}
 				.chevron {
-					background-color: hsl(var(--base-font) / 100%);
+					color: hsl(var(--base-font) / 100%);
 				}
 			}
 
@@ -85,6 +85,85 @@ $description-fontSize: 0.8rem;
 						}
 						&.expanded {
 							border-color: hsl(var(--natural) / 40%);
+						}
+					}
+				}
+			}
+		}
+		&.inherit {
+			border-color: transparent;
+			@include action-hover {
+				background-color: hsl(var(--fg-color) / 5%);
+			}
+			&:focus-within {
+				background-color: hsl(var(--fg-color) / 7%);
+				// border-color: hsl(var(--base) / 10%);
+			}
+			> .toggler {
+				border: none;
+				background-color: transparent;
+				background: transparent;
+				.labelContainer {
+					.icon {
+						color: hsl(var(--fg-color) / 50%);
+					}
+					.label {
+						.title {
+							color: hsl(var(--fg-color) / 100%);
+						}
+						.description {
+							color: hsl(var(--fg-color) / 75%);
+						}
+					}
+				}
+				.chevron {
+					color: hsl(var(--fg-color) / 100%);
+				}
+			}
+
+			&.expanded {
+				background-color: hsl(var(--fg-color) / 5%);
+				@include action-hover {
+					background-color: hsl(var(--fg-color) / 10%);
+				}
+				> .toggler {
+					border: none;
+					background-color: transparent;
+					background: transparent;
+					.labelContainer {
+						.icon {
+							color: hsl(var(--fg-color) / 100%);
+						}
+						.label {
+							.title {
+								color: hsl(var(--fg-color) / 100%);
+							}
+							.description {
+								color: hsl(var(--fg-color) / 100%);
+							}
+						}
+					}
+					.chevron {
+						color: hsl(var(--fg-color) / 100%);
+					}
+				}
+
+				> .content {
+					color: hsl(var(--fg-color) / 100%);
+					:global {
+						.accordionItem {
+							.title {
+								color: hsl(var(--fg-color) / 100%);
+							}
+							&.outline,
+							&:not(.expanded) {
+								.description {
+									color: hsl(var(--fg-color) / 100%) !important;
+								}
+							}
+							&.expanded {
+								border-color: hsl(var(--fg-color) / 40%);
+							}
 						}
 					}
 				}

--- a/src/lib/scss/components/accordionItem/_gradient.scss
+++ b/src/lib/scss/components/accordionItem/_gradient.scss
@@ -38,7 +38,7 @@ $description-fontSize: 0.8rem;
 				}
 			}
 			.chevron {
-				background-color: hsl(var(--base) / 100%);
+				color: hsl(var(--base) / 100%);
 			}
 		}
 		&:focus-within {
@@ -58,7 +58,7 @@ $description-fontSize: 0.8rem;
 					}
 				}
 				.chevron {
-					background-color: hsl(var(--base) / 100%);
+					color: hsl(var(--base) / 100%);
 				}
 			}
 		}
@@ -95,7 +95,7 @@ $description-fontSize: 0.8rem;
 					}
 				}
 				.chevron {
-					background-color: hsl(var(--dark-font) / 100%);
+					color: hsl(var(--dark-font) / 100%);
 				}
 			}
 
@@ -112,6 +112,99 @@ $description-fontSize: 0.8rem;
 						hsl(var(--base) / 90%) 33%,
 						hsl(var(--darker) / 90%)
 					);
+				}
+			}
+		}
+		&.inherit {
+			border-color: transparent;
+			background-color: transparent;
+			// background-color: hsl(var(--natural) / 50%);
+			// background-image: linear-gradient(0deg, hsl(var(--natural) / 20%), hsl(var(--natural) / 20%));
+			// background-image: linear-gradient(-30deg, hsl(var(--base) / 5%) 33%, hsl(var(--darker) / 35%));
+			border-width: 0;
+			@include action-hover {
+				background-color: hsl(var(--fg-color) / 5%);
+			}
+			> .toggler {
+				border: none;
+				background-color: transparent;
+				background: transparent;
+				.labelContainer {
+					.icon {
+						color: hsl(var(--fg-color) / 50%);
+					}
+					.label {
+						.title {
+							color: hsl(var(--fg-color) / 100%);
+						}
+						.description {
+							color: hsl(var(--fg-color) / 75%);
+						}
+					}
+				}
+				.chevron {
+					color: hsl(var(--fg-color) / 80%);
+				}
+			}
+			&:focus-within {
+				background-color: hsl(var(--fg-color) / 7%);
+				> .toggler {
+					.labelContainer {
+						.icon {
+							color: hsl(var(--fg-color) / 100%);
+						}
+						.label {
+							.title {
+								color: hsl(var(--fg-color) / 100%);
+							}
+							.description {
+								color: hsl(var(--fg-color) / 100%);
+							}
+						}
+					}
+					.chevron {
+						color: hsl(var(--fg-color) / 100%);
+					}
+				}
+			}
+			&.expanded {
+				background-color: hsl(var(--fg-color) / 80%);
+				background-image: linear-gradient(
+					-30deg,
+					hsl(var(--fg-color) / 100%) 33%,
+					hsl(var(--bg-color) / 30%)
+				);
+				@include action-hover {
+					background-image: linear-gradient(
+						-30deg,
+						hsl(var(--fg-color) / 80%) 33%,
+						hsl(var(--bg-color) / 20%)
+					);
+					background-color: hsl(var(--fg-color) / 60%);
+				}
+				> .toggler {
+					background-color: transparent;
+					background: transparent;
+					.labelContainer {
+						.icon {
+							color: hsl(var(--bg-color) / 100%);
+						}
+						.label {
+							.title {
+								color: hsl(var(--bg-color) / 100%);
+							}
+							.description {
+								color: hsl(var(--bg-color) / 100%);
+							}
+						}
+					}
+					.chevron {
+						color: hsl(var(--bg-color) / 100%);
+					}
+				}
+
+				> .content {
+					color: hsl(var(--bg-color) / 100%);
 				}
 			}
 		}

--- a/src/lib/scss/components/accordionItem/_outline.scss
+++ b/src/lib/scss/components/accordionItem/_outline.scss
@@ -19,6 +19,20 @@ $description-fontSize: 0.8rem;
 		&:focus-within {
 			border-color: hsl(var(--base) / 25%);
 		}
+		&.simple {
+			border-radius: 0;
+			border-top-width: 0;
+			border-bottom-width: 0;
+			border-inline-end-width: 0;
+			> .content {
+				padding: 0;
+				// 	border-width: $base-borderWidth;
+				// 	border-style: solid;
+				// 	border-color: transparent;
+				// 	padding-inline-start: $base-paddingX;
+				// 	border-inline-start-color: hsl(var(--base) / 100%);
+			}
+		}
 		&.expanded {
 			border-color: hsl(var(--base) / 40%);
 			@include action-hover {
@@ -44,7 +58,45 @@ $description-fontSize: 0.8rem;
 				}
 			}
 			.chevron {
-				background-color: hsl(var(--base) / 100%);
+				color: hsl(var(--base) / 100%);
+			}
+		}
+		&.inherit {
+			@include action-hover {
+				border-color: hsl(var(--fg-color) / 10%);
+			}
+			&:focus-within {
+				border-color: hsl(var(--fg-color) / 25%);
+			}
+			&.expanded {
+				border-color: hsl(var(--fg-color) / 40%);
+				@include action-hover {
+					border-color: hsl(var(--fg-color) / 60%);
+				}
+			}
+
+			// &.simple {
+			// > .content {
+			// border-inline-start-color: hsl(var(--fg-color) / 100%);
+			// }
+			// }
+			> .toggler {
+				.labelContainer {
+					.icon {
+						color: hsl(var(--fg-color) / 100%);
+					}
+					.label {
+						.title {
+							color: hsl(var(--fg-color) / 100%);
+						}
+						.description {
+							color: hsl(var(--fg-color) / 100%);
+						}
+					}
+				}
+				.chevron {
+					color: hsl(var(--fg-color) / 100%);
+				}
 			}
 		}
 	}

--- a/src/lib/svg/icons/chevron-down.ts
+++ b/src/lib/svg/icons/chevron-down.ts
@@ -1,0 +1,1 @@
+export default `<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="32" height="32" preserveAspectRatio="xMidYMid meet" viewBox="0 0 512 512"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="48" d="M112 184l144 144l144-144"></path></svg>`;

--- a/src/routes/accordion.svelte
+++ b/src/routes/accordion.svelte
@@ -8,9 +8,14 @@
 
 <Paper shadow>
 	<Accordion>
-		<AccordionItem color="default" title="Default">
+		<AccordionItem color="default">
 			<svelte:fragment slot="icon">
 				<SVGIcon data={more} />
+			</svelte:fragment>
+			<svelte:fragment slot="title">Default</svelte:fragment>
+			<svelte:fragment slot="description">
+				Default desc Default desc Default desc Default desc Default desc Default desc Default desc
+				Default desc
 			</svelte:fragment>
 			Content default
 		</AccordionItem>

--- a/src/stories/components/Accordion.stories.svelte
+++ b/src/stories/components/Accordion.stories.svelte
@@ -24,7 +24,16 @@
 		color: {
 			control: {
 				type: 'select',
-				options: ['primary', 'secondary', 'warning', 'danger', 'success', 'default', 'info']
+				options: [
+					'inherit',
+					'primary',
+					'secondary',
+					'warning',
+					'danger',
+					'success',
+					'default',
+					'info'
+				]
 			},
 			defaultValue: 'default'
 		},

--- a/src/tests/components/accordion.spec.jsx
+++ b/src/tests/components/accordion.spec.jsx
@@ -65,20 +65,20 @@ describe('AccordionItem component test suite', () => {
 	it('testing interactive color prop change', async () => {
 		const { getByTestId, getAllByTestId, component } = render(Accordion);
 		expect(getByTestId('Accordion')).toBeTruthy();
-		expect(getAllByTestId('AccordionItem')[0]).toHaveClass('default');
-		expect(getAllByTestId('AccordionItem')[1]).toHaveClass('default');
+		expect(getAllByTestId('AccordionItem')[0]).toHaveClass('inherit');
+		expect(getAllByTestId('AccordionItem')[1]).toHaveClass('inherit');
 		expect(getAllByTestId('AccordionItem')[0]).not.toHaveClass('primary');
 		expect(getAllByTestId('AccordionItem')[1]).not.toHaveClass('primary');
 		component.$$set({ color: 'primary' });
 		await tick();
-		expect(getAllByTestId('AccordionItem')[0]).not.toHaveClass('default');
-		expect(getAllByTestId('AccordionItem')[1]).not.toHaveClass('default');
+		expect(getAllByTestId('AccordionItem')[0]).not.toHaveClass('inherit');
+		expect(getAllByTestId('AccordionItem')[1]).not.toHaveClass('inherit');
 		expect(getAllByTestId('AccordionItem')[0]).toHaveClass('primary');
 		expect(getAllByTestId('AccordionItem')[1]).toHaveClass('primary');
 		component.$$set({ color: 'danger' });
 		await tick();
-		expect(getAllByTestId('AccordionItem')[0]).not.toHaveClass('default');
-		expect(getAllByTestId('AccordionItem')[1]).not.toHaveClass('default');
+		expect(getAllByTestId('AccordionItem')[0]).not.toHaveClass('inherit');
+		expect(getAllByTestId('AccordionItem')[1]).not.toHaveClass('inherit');
 		expect(getAllByTestId('AccordionItem')[0]).not.toHaveClass('primary');
 		expect(getAllByTestId('AccordionItem')[1]).not.toHaveClass('primary');
 		expect(getAllByTestId('AccordionItem')[0]).toHaveClass('danger');


### PR DESCRIPTION
- update associated styles
- replace embeded chevron svg as css mask with dedicated `chevronDown` svg component
- remove title property from `AccordionItem` in favor of title slot
- update associated unit tests
- update associated `Storybook`

Signed-off-by: Soren Abedi <soren.abedi@gmail.com>