### PR TITLE
perf: :fire: remove `Throttle` function wrapping the `setScrollHeight` function

### DIFF
--- a/src/lib/utilities/hook/scroll/index.ts
+++ b/src/lib/utilities/hook/scroll/index.ts
@@ -2,7 +2,6 @@ import type { Readable } from 'svelte/store';
 import type { scrollHook } from '../../../types/hook';
 import { browser } from '$app/env';
 import { readable } from 'svelte/store';
-import Throttle from '../../helper/throttle';
 
 export const currentBodyPosition = (): { scrollX: number; scrollY: number } =>
 	browser && { scrollY: window.scrollY, scrollX: window.scrollX };
@@ -10,13 +9,13 @@ let scrollThreshold = 50;
 export const store = readable<scrollHook>(currentBodyPosition(), (set) => {
 	let position = currentBodyPosition().scrollY;
 	/* istanbul ignore next */
-	const setScrollHeight = Throttle(() => {
+	const setScrollHeight = () => {
 		const currentScrollPosition = currentBodyPosition();
 		const direction = position > currentScrollPosition.scrollY ? 'up' : 'down';
 		if (Math.abs(position - currentScrollPosition.scrollY) > scrollThreshold)
 			position = currentScrollPosition.scrollY;
 		set({ ...currentScrollPosition, direction });
-	});
+	};
 	browser && window.addEventListener('scroll', setScrollHeight);
 
 	return () => {


### PR DESCRIPTION
- Increase `ScrollHook` accuracy to the detriment of overhead efficiency

Signed-off-by: Soren Abedi <soren.abedi@gmail.com>