### PR TITLE
feat: :sparkles: bootstrap `resizeHook` utility

### DIFF
--- a/src/lib/utilities/hook/index.ts
+++ b/src/lib/utilities/hook/index.ts
@@ -1,3 +1,4 @@
 export { default as isVisibleHook } from './isVisible';
 export { default as rtlHook } from './rtl';
 export { default as scrollHook } from './scroll';
+export { default as resizeHook } from './resize';

--- a/src/lib/utilities/hook/resize/index.ts
+++ b/src/lib/utilities/hook/resize/index.ts
@@ -1,0 +1,64 @@
+import { browser } from '$app/env';
+import { readable } from 'svelte/store';
+import Debounce from '../../helper/debounce';
+
+type resizeHook = {
+	width: number;
+	height: number;
+	scaleDirection?: 'down' | 'up';
+	scaleFromEdge?: 'horizontal' | 'vertical' | 'both';
+};
+
+const multiplyObjectValues = (obj: { [key: string]: number }) =>
+	Object.values(obj).reduce((a, b) => a * b);
+
+const determineScaleFromEdge = (oldDimensions: resizeHook, newDimensions: resizeHook) => {
+	switch (true) {
+		case oldDimensions.height === newDimensions.height &&
+			oldDimensions.width !== newDimensions.width:
+			return 'horizontal';
+
+		case oldDimensions.height !== newDimensions.height &&
+			oldDimensions.width === newDimensions.width:
+			return 'vertical';
+
+		case oldDimensions.height !== newDimensions.height &&
+			oldDimensions.width !== newDimensions.width:
+			return 'both';
+		default:
+			return undefined;
+	}
+};
+
+const currentWindowSize = (): { width: number; height: number } =>
+	browser ? { width: window.innerWidth, height: window.innerHeight } : undefined;
+export const store = readable<resizeHook>(currentWindowSize(), (set) => {
+	let windowDimensions = currentWindowSize();
+
+	/* istanbul ignore next */
+	const setWindowDimensions = Debounce(() => {
+		const currentWindowDimensions = currentWindowSize();
+		const scaleDirection =
+			multiplyObjectValues(windowDimensions) > multiplyObjectValues(currentWindowDimensions)
+				? 'down'
+				: 'up';
+		const scaleFromEdge: resizeHook['scaleFromEdge'] = determineScaleFromEdge(
+			windowDimensions,
+			currentWindowDimensions
+		);
+		if (
+			Math.abs(
+				multiplyObjectValues(windowDimensions) - multiplyObjectValues(currentWindowDimensions)
+			) > 1
+		)
+			windowDimensions = currentWindowDimensions;
+		set({ ...currentWindowDimensions, scaleDirection, scaleFromEdge });
+	}, 100);
+	browser && window.addEventListener('resize', setWindowDimensions);
+
+	return () => {
+		if (browser) window.removeEventListener('resize', setWindowDimensions);
+	};
+});
+
+export default store;

--- a/src/tests/utilities/hook/resize.spec.jsx
+++ b/src/tests/utilities/hook/resize.spec.jsx
@@ -1,0 +1,109 @@
+import ResizeHook from '$lib/utilities/hook/resize';
+import { jest } from '@jest/globals';
+// import { render, fireEvent } from '@testing-library/svelte';
+
+describe('resize hook test suite', () => {
+	let windowDimensions = {};
+	const removeEventListener = jest.fn();
+	global.removeEventListener = removeEventListener;
+
+	beforeEach(async () => {
+		global.innerHeight = 768;
+		global.innerWidth = 1024;
+		windowDimensions = {};
+	});
+	afterEach(async () => {
+		jest.clearAllMocks();
+	});
+	it('it works', async () => {
+		const destroyHook = ResizeHook.subscribe((hookValues) => {
+			windowDimensions = hookValues;
+		});
+		await new Promise((r) => setTimeout(r, 100));
+		expect(windowDimensions).toHaveProperty('width', 1024);
+		expect(windowDimensions).toHaveProperty('height', 768);
+		expect(removeEventListener).not.toBeCalled();
+		destroyHook();
+		expect(removeEventListener).toBeCalledTimes(1);
+	});
+	it('testing horizontal resize', async () => {
+		const destroyHook = ResizeHook.subscribe((hookValues) => {
+			windowDimensions = hookValues;
+		});
+		global.dispatchEvent(new Event('resize'));
+		await new Promise((r) => setTimeout(r, 100));
+		expect(windowDimensions).toHaveProperty('width', 1024);
+		expect(windowDimensions).toHaveProperty('height', 768);
+		global.innerWidth = 1500;
+		global.dispatchEvent(new Event('resize'));
+		await new Promise((r) => setTimeout(r, 100));
+		expect(windowDimensions).toHaveProperty('height', 768);
+		expect(windowDimensions).toHaveProperty('width', 1500);
+		expect(windowDimensions).toHaveProperty('scaleDirection', 'up');
+		expect(windowDimensions).toHaveProperty('scaleFromEdge', 'horizontal');
+		global.innerWidth = 1200;
+		global.dispatchEvent(new Event('resize'));
+		await new Promise((r) => setTimeout(r, 100));
+		expect(windowDimensions).toHaveProperty('height', 768);
+		expect(windowDimensions).toHaveProperty('width', 1200);
+		expect(windowDimensions).toHaveProperty('scaleDirection', 'down');
+		expect(windowDimensions).toHaveProperty('scaleFromEdge', 'horizontal');
+		expect(removeEventListener).not.toBeCalled();
+		destroyHook();
+		expect(removeEventListener).toBeCalledTimes(1);
+	});
+	it('testing vertical resize', async () => {
+		const destroyHook = ResizeHook.subscribe((hookValues) => {
+			windowDimensions = hookValues;
+		});
+		global.dispatchEvent(new Event('resize'));
+		await new Promise((r) => setTimeout(r, 100));
+		expect(windowDimensions).toHaveProperty('width', 1024);
+		expect(windowDimensions).toHaveProperty('height', 768);
+		global.innerHeight = 1500;
+		global.dispatchEvent(new Event('resize'));
+		await new Promise((r) => setTimeout(r, 100));
+		expect(windowDimensions).toHaveProperty('height', 1500);
+		expect(windowDimensions).toHaveProperty('width', 1024);
+		expect(windowDimensions).toHaveProperty('scaleDirection', 'up');
+		expect(windowDimensions).toHaveProperty('scaleFromEdge', 'vertical');
+		global.innerHeight = 1200;
+		global.dispatchEvent(new Event('resize'));
+		await new Promise((r) => setTimeout(r, 100));
+		expect(windowDimensions).toHaveProperty('height', 1200);
+		expect(windowDimensions).toHaveProperty('width', 1024);
+		expect(windowDimensions).toHaveProperty('scaleDirection', 'down');
+		expect(windowDimensions).toHaveProperty('scaleFromEdge', 'vertical');
+		expect(removeEventListener).not.toBeCalled();
+		destroyHook();
+		expect(removeEventListener).toBeCalledTimes(1);
+	});
+	it('testing vertical and horizontal resize at the same time', async () => {
+		const destroyHook = ResizeHook.subscribe((hookValues) => {
+			windowDimensions = hookValues;
+		});
+		global.dispatchEvent(new Event('resize'));
+		await new Promise((r) => setTimeout(r, 100));
+		expect(windowDimensions).toHaveProperty('width', 1024);
+		expect(windowDimensions).toHaveProperty('height', 768);
+		global.innerHeight = 1500;
+		global.innerWidth = 1400;
+		global.dispatchEvent(new Event('resize'));
+		await new Promise((r) => setTimeout(r, 100));
+		expect(windowDimensions).toHaveProperty('height', 1500);
+		expect(windowDimensions).toHaveProperty('width', 1400);
+		expect(windowDimensions).toHaveProperty('scaleDirection', 'up');
+		expect(windowDimensions).toHaveProperty('scaleFromEdge', 'both');
+		global.innerHeight = 1200;
+		global.innerWidth = 1100;
+		global.dispatchEvent(new Event('resize'));
+		await new Promise((r) => setTimeout(r, 100));
+		expect(windowDimensions).toHaveProperty('height', 1200);
+		expect(windowDimensions).toHaveProperty('width', 1100);
+		expect(windowDimensions).toHaveProperty('scaleDirection', 'down');
+		expect(windowDimensions).toHaveProperty('scaleFromEdge', 'both');
+		expect(removeEventListener).not.toBeCalled();
+		destroyHook();
+		expect(removeEventListener).toBeCalledTimes(1);
+	});
+});


### PR DESCRIPTION
- add associated unit tests
- add utility to module exports

Signed-off-by: Soren Abedi <soren.abedi@gmail.com>