### PR TITLE
fix(patch): :lipstick: remove hard coded `font-size` style in `Link` component scss

### DIFF
--- a/src/lib/scss/components/link/_base.scss
+++ b/src/lib/scss/components/link/_base.scss
@@ -11,7 +11,6 @@ $base-paddingY: 0;
 		font-size: inherit;
 		box-sizing: border-box;
 		cursor: pointer;
-		font-size: 18px;
 		position: relative;
 		white-space: nowrap;
 		color: hsl(var(--base));


### PR DESCRIPTION
Signed-off-by: Soren Abedi <soren.abedi@gmail.com>