### PR TITLE
ci(docs-only): :construction_worker: update `publish` CI to be skipped when commit message contains `docs-only`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   code-structure-test:
     runs-on: ${{ matrix.os }}
+    if: ${{ !contains(github.event.head_commit.message, 'docs-only') }}
 
     strategy:
       matrix:


### PR DESCRIPTION
Signed-off-by: Soren Abedi <soren.abedi@gmail.com>